### PR TITLE
Plugin improvements

### DIFF
--- a/jquery.dynamicSelect.js
+++ b/jquery.dynamicSelect.js
@@ -16,20 +16,21 @@
  * Licensed under the MIT license
  */
 
-;(function ( $, window, document, undefined ) {
+(function ( $, window, document, undefined ) {
 
     // Create the defaults once
     var pluginName = 'dynamicSelect',
         defaults = {
             noSelectValue : "",
             optionValues : {}
-        };
+    };
 
     // The actual plugin constructor
-    function Plugin( element, options ) {
+    function Plugin( element, options )
+    {
         this.element = element;
 
-        this.options = $.extend( {}, defaults, options) ;
+        this.options = $.extend({}, defaults, options);
 
         this._defaults = defaults;
         this._name = pluginName;
@@ -40,6 +41,7 @@
         this.noSelectValue = this.options.noSelectValue;
         this.previousDefaultValue = this.options.previousDefaultValue;
         this.existingOptionValues = this.options.optionValues;
+        this.preSelectedValues = this.options.preSelectedValues;
         this.hideNext = this.options.hideNext;
         this.context = this.element;
 
@@ -52,29 +54,30 @@
 
     Plugin.prototype = {
 
-        init: function() {
+        init: function () {
 
             this.populateSelect({true: this.structure}, -1, true);
             this.disableNextSelects(-1);
 
-            for (var i = 0; i < this.selectors.length - 1; i++) {
+            var selectors_length = this.selectors.length;
+            for (var i = 0; i < selectors_length - 1; i++) {
                 var selector = this.selectors[i];
-                $(this.context).on("change", selector, {"level": i, "plugin": this}, function(event) {
+                $(this.context).on("change", selector, {"level": i, "plugin": this}, function (event) {
                     var val = $("option:selected", $(this)).text();
                     var level = event.data.level;
                     var plugin = event.data.plugin;
                     var substructure = plugin.calculateSubstructure(level);
                     plugin.populateSelect(substructure, level, val);
                     plugin.disableNextSelects(level);
-               });
+                });
             }
         },
 
-        getOptionValue: function( key ) {
+        getOptionValue: function ( key ) {
             return (key in this.existingOptionValues) ? this.existingOptionValues[key] : key;
         },
 
-        populateSelect: function( substructure, level, optionValue ) {
+        populateSelect: function ( substructure, level, optionValue ) {
             if (optionValue === this.captions[level]) {
                 return false;
             }
@@ -83,6 +86,7 @@
             var optionsObject = substructure[optionValue];
             if (typeof optionsObject === "undefined") {
                 this.disableNextSelects(level - 1);
+
                 return false;
             }
 
@@ -91,10 +95,11 @@
             // skip rendering next select-box if there are no options for it
             if (0 === optionsToPopulate.length) {
                 this.disableNextSelects(level - 1);
+
                 return false;
             }
 
-            var options = "<option class='dynamic-select-option' value=" + this.defaultSelectValue(level + 1) +">" + this.captions[level+1] + "</option>";
+            var options = "<option class='dynamic-select-option' value=" + this.defaultSelectValue(level + 1) + ">" + this.captions[level + 1] + "</option>";
             for (var key in optionsToPopulate) {
                 var optionText = optionsToPopulate[key];
                 optionValue = this.getOptionValue(optionText);
@@ -110,7 +115,7 @@
             }
         },
 
-        calculateSubstructure: function( level ) {
+        calculateSubstructure: function ( level ) {
             if (level === 0) {
                 return this.structure;
             } else {
@@ -125,8 +130,9 @@
             }
         },
 
-        disableNextSelects: function( level ) {
-            for (var i = level + 2; i <= this.selectors.length; i++) {
+        disableNextSelects: function ( level ) {
+            var selectors_length = this.selectors.length;
+            for (var i = level + 2; i <= selectors_length; i++) {
                 var selector = this.selectors[i];
 
                 $(selector, this.context).prop("disabled", "disabled")
@@ -138,7 +144,7 @@
             }
         },
 
-        defaultSelectValue: function( level ) {
+        defaultSelectValue: function ( level ) {
             var result = this.noSelectValue;
             // use previous select-box value as current select-box default value
             if (this.previousDefaultValue) {
@@ -148,43 +154,47 @@
             return result;
         },
 
-        createKeysMethodIfNecessary: function() {
+        createKeysMethodIfNecessary: function () {
             if (typeof Object.keys !== "function") {
-                (function() {
+                (function () {
                     Object.keys = Object_keys;
-                    function Object_keys(obj) {
+                    function Object_keys(obj)
+                    {
                         var keys = [], name;
                         for (name in obj) {
                             if (obj.hasOwnProperty(name)) {
                                 keys.push(name);
                             }
                         }
+
                         return keys;
                     }
                 })();
             }
         },
 
-        createSelectorsIfNecessary: function() {
+        createSelectorsIfNecessary: function () {
             if (typeof this.selectors === "undefined") {
                 var numOfSelects = $("select", this.context).length;
                 var selectors = new Array(numOfSelects);
                 for (var i = 0; i < numOfSelects; i++) {
                     selectors[i] = "select:eq(" + i + ")";
                 }
+
                 return selectors;
             } else {
                 return this.selectors;
             }
         },
 
-        createCaptionsIfNecessary: function() {
+        createCaptionsIfNecessary: function () {
             if (typeof this.captions === "undefined") {
                 var numOfSelects = this.selectors.length;
                 var captions = new Array(numOfSelects);
                 for (var i = 0; i < numOfSelects; i++) {
                     captions[i] = "&nbsp;";
                 }
+
                 return captions;
             } else {
                 return this.captions;
@@ -197,8 +207,7 @@
     $.fn[pluginName] = function ( options ) {
         return this.each(function () {
             if (!$.data(this, 'plugin_' + pluginName)) {
-                $.data(this, 'plugin_' + pluginName,
-                new Plugin( this, options ));
+                $.data(this, 'plugin_' + pluginName, new Plugin(this, options));
             }
         });
     };

--- a/jquery.dynamicSelect.js
+++ b/jquery.dynamicSelect.js
@@ -38,6 +38,7 @@
         this.structure = this.options.structure;
         this.captions = this.options.captions;
         this.noSelectValue = this.options.noSelectValue;
+        this.previousDefaultValue = this.options.previousDefaultValue;
         this.existingOptionValues = this.options.optionValues;
         this.hideNext = this.options.hideNext;
         this.context = this.element;
@@ -92,7 +93,7 @@
                 return false;
             }
 
-            var options = "<option class='dynamic-select-option' value=" + this.noSelectValue +">" + this.captions[level+1] + "</option>";
+            var options = "<option class='dynamic-select-option' value=" + this.defaultSelectValue(level + 1) +">" + this.captions[level+1] + "</option>";
             for (var key in optionsToPopulate){
                 var optionText = optionsToPopulate[key];
                 optionValue = this.getOptionValue(optionText);
@@ -128,13 +129,25 @@
         disableNextSelects: function(level){
             for (var i = level + 2; i <= this.selectors.length; i++) {
                 var selector = this.selectors[i];
+
+
                 $(selector, this.context).prop("disabled", "disabled")
                     .removeClass("dynamic-select-enabled dynamic-select-active")
-                    .html("<option class='dynamic-select-option' value=" + this.noSelectValue +">" + this.captions[i] + "</option>");
+                    .html("<option class='dynamic-select-option' value=" + this.defaultSelectValue(level) + ">" + this.captions[i] + "</option>");
                 if (this.hideNext) {
                     $(selector, this.context).hide();
                 }
             }
+        },
+
+        defaultSelectValue: function(level) {
+            var result = this.noSelectValue;
+            // use previous select-box value as current select-box default value
+            if (this.previousDefaultValue) {
+                result = $(this.selectors[level - 1], this.context).val();
+            }
+
+            return result;
         },
 
         createKeysMethodIfNecessary: function(){

--- a/jquery.dynamicSelect.js
+++ b/jquery.dynamicSelect.js
@@ -49,9 +49,9 @@
     }
 
     Plugin.prototype = {
-        
+
         init: function() {
-            
+
             this.populateSelect({true: this.structure}, -1, true);
             this.disableNextSelects(-1);
 
@@ -67,7 +67,7 @@
                                    });
             }
         },
-        
+
         getOptionValue: function(key){
             return (key in this.existingOptionValues) ? this.existingOptionValues[key] : key;
         },
@@ -108,8 +108,8 @@
                     substructure = substructure[mainValue];
                 }
 
-                return substructure;    
-                
+                return substructure;
+
             }
         },
 
@@ -144,7 +144,7 @@
                 var numOfSelects = $("select", this.context).length;
                 var selectors = new Array(numOfSelects);
                 for (var i = 0; i < numOfSelects; i++) {
-                    selectors[i] = "select:eq(" + i + ")";                
+                    selectors[i] = "select:eq(" + i + ")";
                 }
                 return selectors;
             }
@@ -165,7 +165,7 @@
             else{
                 return this.captions;
             }
-        }        
+        }
     };
 
     // A really lightweight plugin wrapper around the constructor,

--- a/jquery.dynamicSelect.js
+++ b/jquery.dynamicSelect.js
@@ -85,6 +85,12 @@
 
             var optionsToPopulate = $.isArray(optionsObject) ? optionsObject : Object.keys(substructure[optionValue]);
 
+            // skip rendering next select-box if there are no options for it
+            if (0 === optionsToPopulate.length) {
+                this.disableNextSelects(level - 1);
+                return false;
+            }
+
             var options = "<option class='dynamic-select-option' value=" + this.noSelectValue +">" + this.captions[level+1] + "</option>";
             for (var key in optionsToPopulate){
                 var optionText = optionsToPopulate[key];

--- a/jquery.dynamicSelect.js
+++ b/jquery.dynamicSelect.js
@@ -99,7 +99,9 @@
         },
 
         calculateSubstructure: function(level){
-            if (level == 0) {return this.structure}
+            if (level === 0) {
+                return this.structure;
+            }
             else{
                 var substructure = this.structure;
                 for (var i = 0; i < level; i++) {

--- a/jquery.dynamicSelect.js
+++ b/jquery.dynamicSelect.js
@@ -86,7 +86,7 @@
             var optionsToPopulate = $.isArray(optionsObject) ? optionsObject : Object.keys(substructure[optionValue]);
 
             var options = "<option class='dynamic-select-option' value=" + this.noSelectValue +">" + this.captions[level+1] + "</option>";
-            for (key in optionsToPopulate){
+            for (var key in optionsToPopulate){
                 var optionText = optionsToPopulate[key];
                 var optionValue = this.getOptionValue(optionText);
                 options += "<option class='dynamic-select-option' value='" + optionValue + "'>" + optionText + "</option>";

--- a/jquery.dynamicSelect.js
+++ b/jquery.dynamicSelect.js
@@ -58,13 +58,13 @@
             for (var i = 0; i < this.selectors.length - 1; i++) {
                 var selector = this.selectors[i];
                 $(this.context).on("change", selector, {"level": i, "plugin": this}, function(event){
-                                        var val = $("option:selected", $(this)).text();
-                                        var level = event.data.level;
-                                        var plugin = event.data.plugin;
-                                        var substructure = plugin.calculateSubstructure(level);
-                                        plugin.populateSelect(substructure, level, val);
-                                        plugin.disableNextSelects(level);
-                                   });
+                    var val = $("option:selected", $(this)).text();
+                    var level = event.data.level;
+                    var plugin = event.data.plugin;
+                    var substructure = plugin.calculateSubstructure(level);
+                    plugin.populateSelect(substructure, level, val);
+                    plugin.disableNextSelects(level);
+               });
             }
         },
 
@@ -117,9 +117,9 @@
             for (var i = level + 2; i <= this.selectors.length; i++) {
                 var selector = this.selectors[i];
                 $(selector, this.context).prop("disabled", "disabled")
-                                    .removeClass("dynamic-select-enabled dynamic-select-active")
-                                    .html("<option class='dynamic-select-option' value=" + this.noSelectValue +">" + this.captions[i] + "</option>");
-            };
+                    .removeClass("dynamic-select-enabled dynamic-select-active")
+                    .html("<option class='dynamic-select-option' value=" + this.noSelectValue +">" + this.captions[i] + "</option>");
+            }
         },
 
         createKeysMethodIfNecessary: function(){

--- a/jquery.dynamicSelect.js
+++ b/jquery.dynamicSelect.js
@@ -88,7 +88,7 @@
             var options = "<option class='dynamic-select-option' value=" + this.noSelectValue +">" + this.captions[level+1] + "</option>";
             for (var key in optionsToPopulate){
                 var optionText = optionsToPopulate[key];
-                var optionValue = this.getOptionValue(optionText);
+                optionValue = this.getOptionValue(optionText);
                 options += "<option class='dynamic-select-option' value='" + optionValue + "'>" + optionText + "</option>";
             }
 
@@ -179,6 +179,6 @@
                 new Plugin( this, options ));
             }
         });
-    }
+    };
 
 })( jQuery, window, document );

--- a/jquery.dynamicSelect.js
+++ b/jquery.dynamicSelect.js
@@ -59,7 +59,7 @@
 
             for (var i = 0; i < this.selectors.length - 1; i++) {
                 var selector = this.selectors[i];
-                $(this.context).on("change", selector, {"level": i, "plugin": this}, function(event){
+                $(this.context).on("change", selector, {"level": i, "plugin": this}, function(event) {
                     var val = $("option:selected", $(this)).text();
                     var level = event.data.level;
                     var plugin = event.data.plugin;
@@ -70,11 +70,11 @@
             }
         },
 
-        getOptionValue: function(key){
+        getOptionValue: function( key ) {
             return (key in this.existingOptionValues) ? this.existingOptionValues[key] : key;
         },
 
-        populateSelect: function(substructure, level, optionValue) {
+        populateSelect: function( substructure, level, optionValue ) {
             if (optionValue === this.captions[level]) {
                 return false;
             }
@@ -95,7 +95,7 @@
             }
 
             var options = "<option class='dynamic-select-option' value=" + this.defaultSelectValue(level + 1) +">" + this.captions[level+1] + "</option>";
-            for (var key in optionsToPopulate){
+            for (var key in optionsToPopulate) {
                 var optionText = optionsToPopulate[key];
                 optionValue = this.getOptionValue(optionText);
                 options += "<option class='dynamic-select-option' value='" + optionValue + "'>" + optionText + "</option>";
@@ -103,18 +103,17 @@
 
             $(currentSelect, this.context).removeClass("dynamic-select-active");
             $(nextSelect, this.context).html(options)
-                                   .addClass("dynamic-select-active dynamic-select-enabled")
-                                   .removeAttr("disabled");
+                .addClass("dynamic-select-active dynamic-select-enabled")
+                .removeAttr("disabled");
             if (this.hideNext) {
                 $(nextSelect, this.context).show();
             }
         },
 
-        calculateSubstructure: function(level){
+        calculateSubstructure: function( level ) {
             if (level === 0) {
                 return this.structure;
-            }
-            else{
+            } else {
                 var substructure = this.structure;
                 for (var i = 0; i < level; i++) {
                     var mainSelector = this.selectors[i];
@@ -123,14 +122,12 @@
                 }
 
                 return substructure;
-
             }
         },
 
-        disableNextSelects: function(level){
+        disableNextSelects: function( level ) {
             for (var i = level + 2; i <= this.selectors.length; i++) {
                 var selector = this.selectors[i];
-
 
                 $(selector, this.context).prop("disabled", "disabled")
                     .removeClass("dynamic-select-enabled dynamic-select-active")
@@ -141,7 +138,7 @@
             }
         },
 
-        defaultSelectValue: function(level) {
+        defaultSelectValue: function( level ) {
             var result = this.noSelectValue;
             // use previous select-box value as current select-box default value
             if (this.previousDefaultValue) {
@@ -151,7 +148,7 @@
             return result;
         },
 
-        createKeysMethodIfNecessary: function(){
+        createKeysMethodIfNecessary: function() {
             if (typeof Object.keys !== "function") {
                 (function() {
                     Object.keys = Object_keys;
@@ -168,7 +165,7 @@
             }
         },
 
-        createSelectorsIfNecessary: function(){
+        createSelectorsIfNecessary: function() {
             if (typeof this.selectors === "undefined") {
                 var numOfSelects = $("select", this.context).length;
                 var selectors = new Array(numOfSelects);
@@ -176,13 +173,12 @@
                     selectors[i] = "select:eq(" + i + ")";
                 }
                 return selectors;
-            }
-            else{
+            } else {
                 return this.selectors;
             }
         },
 
-        createCaptionsIfNecessary: function(){
+        createCaptionsIfNecessary: function() {
             if (typeof this.captions === "undefined") {
                 var numOfSelects = this.selectors.length;
                 var captions = new Array(numOfSelects);
@@ -190,8 +186,7 @@
                     captions[i] = "&nbsp;";
                 }
                 return captions;
-            }
-            else{
+            } else {
                 return this.captions;
             }
         }

--- a/jquery.dynamicSelect.js
+++ b/jquery.dynamicSelect.js
@@ -39,6 +39,7 @@
         this.captions = this.options.captions;
         this.noSelectValue = this.options.noSelectValue;
         this.existingOptionValues = this.options.optionValues;
+        this.hideNext = this.options.hideNext;
         this.context = this.element;
 
         this.createKeysMethodIfNecessary();
@@ -102,6 +103,9 @@
             $(nextSelect, this.context).html(options)
                                    .addClass("dynamic-select-active dynamic-select-enabled")
                                    .removeAttr("disabled");
+            if (this.hideNext) {
+                $(nextSelect, this.context).show();
+            }
         },
 
         calculateSubstructure: function(level){
@@ -127,6 +131,9 @@
                 $(selector, this.context).prop("disabled", "disabled")
                     .removeClass("dynamic-select-enabled dynamic-select-active")
                     .html("<option class='dynamic-select-option' value=" + this.noSelectValue +">" + this.captions[i] + "</option>");
+                if (this.hideNext) {
+                    $(selector, this.context).hide();
+                }
             }
         },
 

--- a/jquery.dynamicSelect.js
+++ b/jquery.dynamicSelect.js
@@ -82,6 +82,7 @@
             var nextSelect = this.selectors[level + 1];
             var optionsObject = substructure[optionValue];
             if (typeof optionsObject === "undefined") {
+                this.disableNextSelects(level - 1);
                 return false;
             }
 


### PR DESCRIPTION
* Added `hideNext` option for hiding disabled select-boxes
* Added `previousDefaultValue` option. If set, the default value of the next select-box will be set to the selected value of the previous select-box.
* Skip rendering of next select-box if there are no options
* Disable all next select-boxes if `optionsObject` is `undefined`
* Code styling fixes